### PR TITLE
Add .gitignore to exclude GitHub workflows directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+github/workflows/


### PR DESCRIPTION
Introduce a .gitignore file to prevent the GitHub workflows directory from being tracked in the repository.